### PR TITLE
Changed CustomizeText to feed upon the globals

### DIFF
--- a/src/start_menu/main_settings/change_text_size.cpp
+++ b/src/start_menu/main_settings/change_text_size.cpp
@@ -6,5 +6,5 @@ void ChangeTextSize()
 {
 	std::cout << "Pick text size number" << std::endl;
 	utils::GetUserInput(utils::g_text_size);
-	utils::CustomizeText(utils::g_text_size);
+	utils::CustomizeText();
 }

--- a/src/start_menu/main_settings/change_text_weight.cpp
+++ b/src/start_menu/main_settings/change_text_weight.cpp
@@ -20,27 +20,27 @@ void ChangeTextWeight()
 		{
 			case 1:
 				{
-					utils::CustomizeText(utils::g_text_size, utils::Light);
+					utils::g_text_weight = utils::FontWeightValues::Light;
 					break;
 				}
 			case 2:
 				{
-					utils::CustomizeText(utils::g_text_size, utils::SemiLight);
+					utils::g_text_weight = utils::FontWeightValues::SemiLight;
 					break;
 				}
 			case 3:
 				{
-					utils::CustomizeText(utils::g_text_size, utils::Normal);
+					utils::g_text_weight = utils::FontWeightValues::Normal;
 					break;
 				}
 			case 4:
 				{
-					utils::CustomizeText(utils::g_text_size, utils::SemiBold);
+					utils::g_text_weight = utils::FontWeightValues::SemiBold;
 					break;
 				}
 			case 5:
 				{
-					utils::CustomizeText(utils::g_text_size, utils::Bold);
+					utils::g_text_weight = utils::FontWeightValues::Bold;
 					break;
 				}
 			default:
@@ -49,7 +49,10 @@ void ChangeTextWeight()
 					continue;
 				}
 		}
-		break;
+
+		utils::CustomizeText(); // Make the new changes take effect
+
+		break; // Exit the do...while loop
 	}
 	while (true);
 }

--- a/src/utils/customize_text/customize_text.cpp
+++ b/src/utils/customize_text/customize_text.cpp
@@ -4,16 +4,17 @@
 
 int utils::g_text_size = 16;
 utils::FontWeightValues utils::g_text_weight = utils::FontWeightValues::Normal;
+std::wstring utils::g_text_face_name = L"Consolas";
 
-void utils::CustomizeText(int font_size, utils::FontWeightValues font_weight, const wchar_t* face_name)
+void utils::CustomizeText()
 {
 	CONSOLE_FONT_INFOEX cfi;
 	cfi.cbSize = sizeof(cfi);
 	cfi.nFont = 0; // The index of the font in the system's console font table.
 	cfi.dwFontSize.X = 0; // A COORD structure that contains the width and height of each character in the font.
-	cfi.dwFontSize.Y = font_size; //   The X member contains the width, while the Y member contains the height.
+	cfi.dwFontSize.Y = g_text_size; //   The X member contains the width, while the Y member contains the height.
 	cfi.FontFamily = FF_DONTCARE; // The font pitch and family. See also TEXTMETRICA.
-	cfi.FontWeight = font_weight; // The font weight. The weight can range from 100 to 1000, in multiples of 100.
-	std::wcscpy(cfi.FaceName, face_name); // Copies the desired typeface over to FaceName.
+	cfi.FontWeight = g_text_weight; // The font weight. The weight can range from 100 to 1000, in multiples of 100.
+	std::wcscpy(cfi.FaceName, g_text_face_name.c_str()); // Copies the desired typeface over to FaceName.
 	SetCurrentConsoleFontEx(GetStdHandle(STD_OUTPUT_HANDLE), FALSE, &cfi);
 }

--- a/src/utils/customize_text/customize_text.h
+++ b/src/utils/customize_text/customize_text.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 namespace utils
 {
@@ -11,20 +12,20 @@ enum FontWeightValues
 	Bold = 800
 };
 
+// An integer indicating how large the font will be.
 extern int g_text_size;
+// The weight of the font, one of: Light, SemiLight, Normal, SemiBold, Bold.
 extern FontWeightValues g_text_weight;
+// A wstring for the font typeface used.
+extern std::wstring g_text_face_name;
 
 /**
- * @brief A function that changes the basic aesthetics of the text. This is only in a real cmd,
- * and should probably be changed when an (inevitable) switch to virtual terminal happens.
- * For now, it works as a proof of concept, and a starting point for further development.
- * Read more: https://learn.microsoft.com/en-us/windows/console/console-font-infoex?redirectedfrom=MSDN
+ * @brief A function that changes the basic aesthetics of the text.
+ * It sets the values of the global text variables to the appropriate places
+ * in the console font infoex.
  *
- * @param font_size An integer indicating how large the font will be.
- * @param font_weight The weight of the font, one of: Light, SemiLight, Normal, SemiBold, Bold.
- * @param face_name A wchar_t string for the font typeface used.
+ * Call this function after any change to the global text variables occurs,
+ * for it to take effect.
  */
-void CustomizeText(int font_size = g_text_size,
-	FontWeightValues font_weight = g_text_weight,
-	const wchar_t* face_name = L"Courier");
+void CustomizeText();
 } // namespace utils


### PR DESCRIPTION
There was a flaw in the connection between `CustomizeText` and the global text variables. This PR makes the function set the values from the globals to the appropriate places, instead of having them as parameters.

Ideally, the global variables should be placed in a `class` and have their setter methods call `CustomizeText`, so that whenever a global variable changes, the function gets called automatically. However, this observer pattern seems like an overkill for our current situation, therefore a simpler approach was decided upon.

closes #40 