### PR TITLE
moved text speed selection at the start of the new game

### DIFF
--- a/src/loading_screen/loading_screen.cpp
+++ b/src/loading_screen/loading_screen.cpp
@@ -7,7 +7,4 @@ void LoadingScreen()
 	std::cout << "Welcome to our text-based game! Get ready to explore a world "
 				 "of adventure, where every choice counts. Have fun!"
 			  << std::endl;
-	std::cout << "Give me the time you want between each rendered "
-				 "character (in ms): ";
-	utils::GetUserInput(utils::g_sleep_for_ms);
 }

--- a/src/start_menu/start_game/start_game.cpp
+++ b/src/start_menu/start_game/start_game.cpp
@@ -9,6 +9,12 @@ void StartGame(MainCharacter& main_character)
 
 	utils::ClearScreen();
 
+	std::cout << "Give me the time you want between each rendered "
+				 "character (in ms): ";
+	utils::GetUserInput(utils::g_sleep_for_ms);
+
+	utils::ClearScreen();
+
 	CreateCharacter(main_character);
 
 	SaveGame(main_character);

--- a/src/utils/print/print.cpp
+++ b/src/utils/print/print.cpp
@@ -3,7 +3,7 @@
 #include <thread>
 #include <chrono>
 
-int utils::g_sleep_for_ms = 100;
+int utils::g_sleep_for_ms = 50;
 
 void utils::Print(std::initializer_list<std::string> list, int sleep_for_ms)
 {


### PR DESCRIPTION
closes #51 

moved text speed selection for the loading of the game to the start of the new game, in all other cases the text speed is the default of the text speed that is saved 